### PR TITLE
update hexo-helper-github-issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3730,8 +3730,8 @@
       }
     },
     "hexo-hepler-github-issues": {
-      "version": "github:jpaztech/hexo-helper-github-issues#e0875dc927f015a4a53c669e2648b57b9cf37ccf",
-      "from": "github:jpaztech/hexo-helper-github-issues",
+      "version": "github:jpazureid/hexo-helper-github-issues#5fff360b3817eec1b1942dcfa48bb5b61b3b8dd0",
+      "from": "github:jpazureid/hexo-helper-github-issues",
       "dev": true,
       "requires": {
         "uuid": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "hexo-generator-root-tag": "github:jpaztech/hexo-generator-root-tag",
     "hexo-generator-sitemap": "^2.0.0",
     "hexo-generator-tag": "^1.0.0",
-    "hexo-hepler-github-issues": "github:jpaztech/hexo-helper-github-issues",
+    "hexo-hepler-github-issues": "github:jpazureid/hexo-helper-github-issues",
     "hexo-renderer-ejs": "^1.0.0",
     "hexo-renderer-marked": "^2.0.0",
     "hexo-renderer-stylus": "^1.1.0",


### PR DESCRIPTION
fix hexo-helper-github-issue plugin for blog which use main branch as default.