### PR TITLE
Sort posts by date

### DIFF
--- a/lib/hexo-generator-root-tag/lib/generator.js
+++ b/lib/hexo-generator-root-tag/lib/generator.js
@@ -7,6 +7,7 @@ const defaultOption = require('./helper').defaultOption;
 module.exports = function(locals) {
   const config = this.config;
   const perPage = config.tag_generator.per_page;
+  const orderBy = config.tag_generator.order_by || '-date';
   const tags = locals.tags;
   let rootTagOption = Object.assign({}, defaultOption);
   if (config.root_tag_generator && config.root_tag_generator.root_tag_names) {
@@ -19,7 +20,8 @@ module.exports = function(locals) {
   postsMap.forEach((childTagPosts, rootTag) => {
     childTagPosts.forEach((childPosts, childTag) => {
       const path = `tags/${rootTag.slug}/${childTag.slug}/`;
-      const data = pagination(path, childPosts, {
+      const sortedChildPosts = childPosts.sort(orderBy);
+      const data = pagination(path, sortedChildPosts, {
         perPage: perPage,
         layout: ['tag', 'archive', 'index'],
         format: '/%d/',


### PR DESCRIPTION
This PR fixes the issue that posts are not sorted by date in tags page.

Related: https://github.com/jpazureid/hexo-generator-root-tag/pull/3

![image](https://user-images.githubusercontent.com/1394098/211432861-007a4b59-decd-4f19-84e1-d7cc27e32f28.png)